### PR TITLE
Add trace count to histogram export

### DIFF
--- a/src/main/python/widgets/base_window.py
+++ b/src/main/python/widgets/base_window.py
@@ -750,13 +750,22 @@ class BaseWindow(QMainWindow):
             else:
                 df = pd.DataFrame({"E": [], "S": []})
 
+            n_traces = self.data.histData.n_samples
+            if n_traces is None:
+                n_traces = len(
+                    [t for t in self.data.traces.values() if t.is_checked]
+                )
+            ntraces_txt = "N_traces: {}".format(n_traces)
+
             with open(path, "w") as f:
                 f.write(
                     "{0}\n"
-                    "{1}\n\n"
-                    "{2}".format(
+                    "{1}\n"
+                    "{2}\n\n"
+                    "{3}".format(
                         exp_txt,
                         date_txt,
+                        ntraces_txt,
                         df.to_csv(index=False, sep="\t", na_rep="NaN"),
                     )
                 )

--- a/src/main/python/widgets/histogram_window.py
+++ b/src/main/python/widgets/histogram_window.py
@@ -103,13 +103,17 @@ class HistogramWindow(BaseWindow):
             else:
                 df = pd.DataFrame({"E": [], "S": []})
 
+            ntraces_txt = "N_traces: {}".format(self.n_samples)
+
             with open(path, "w") as f:
                 f.write(
                     "{0}\n"
-                    "{1}\n\n"
-                    "{2}".format(
+                    "{1}\n"
+                    "{2}\n\n"
+                    "{3}".format(
                         exp_txt,
                         date_txt,
+                        ntraces_txt,
                         df.to_csv(index=False, sep="\t", na_rep="NaN"),
                     )
                 )


### PR DESCRIPTION
## Summary
- include trace count in exported E–S histogram files

## Testing
- `pre-commit run --files src/main/python/widgets/base_window.py src/main/python/widgets/histogram_window.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541f06ed648324b083329e0e156761