### PR TITLE
Implement manual blink removal

### DIFF
--- a/src/main/python/ui/MenuBar.ui
+++ b/src/main/python/ui/MenuBar.ui
@@ -130,6 +130,12 @@
      <addaction name="actionSelect_Bleach_Red_Channel"/>
      <addaction name="actionSelect_Bleach_Green_Channel"/>
     </widget>
+    <widget class="QMenu" name="menuManually_Select_Blinking">
+     <property name="title">
+      <string>Manually Select Blinking</string>
+     </property>
+     <addaction name="actionSelect_Blink_Interval"/>
+    </widget>
     <widget class="QMenu" name="menuPredict_Trace_Type">
      <property name="title">
       <string>Predict Trace Type</string>
@@ -154,6 +160,7 @@
     <addaction name="actionClear_Correction_Factors"/>
     <addaction name="separator"/>
     <addaction name="menuManually_Select_Bleaching"/>
+    <addaction name="menuManually_Select_Blinking"/>
     <addaction name="separator"/>
     <addaction name="actionFit_Hmm_Selected"/>
     <addaction name="menuPredict_Trace_Type"/>
@@ -581,6 +588,14 @@
    </property>
    <property name="text">
     <string>Green Channel</string>
+   </property>
+  </action>
+  <action name="actionSelect_Blink_Interval">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Blink Interval</string>
    </property>
   </action>
   <action name="actionAdvanced_Sort">

--- a/src/main/python/ui/_MenuBar.py
+++ b/src/main/python/ui/_MenuBar.py
@@ -66,6 +66,10 @@ class Ui_MenuBar(object):
         self.menuManually_Select_Bleaching.setObjectName(
             "menuManually_Select_Bleaching"
         )
+        self.menuManually_Select_Blinking = QtWidgets.QMenu(self.menuAnalyze)
+        self.menuManually_Select_Blinking.setObjectName(
+            "menuManually_Select_Blinking"
+        )
         self.menuPredict_Trace_Type = QtWidgets.QMenu(self.menuAnalyze)
         self.menuPredict_Trace_Type.setObjectName("menuPredict_Trace_Type")
         self.menuWindow = QtWidgets.QMenu(self.menuBar)
@@ -215,6 +219,11 @@ class Ui_MenuBar(object):
         self.actionSelect_Bleach_Green_Channel.setObjectName(
             "actionSelect_Bleach_Green_Channel"
         )
+        self.actionSelect_Blink_Interval = QtWidgets.QAction(MenuBar)
+        self.actionSelect_Blink_Interval.setEnabled(False)
+        self.actionSelect_Blink_Interval.setObjectName(
+            "actionSelect_Blink_Interval"
+        )
         self.actionAdvanced_Sort = QtWidgets.QAction(MenuBar)
         self.actionAdvanced_Sort.setEnabled(False)
         self.actionAdvanced_Sort.setObjectName("actionAdvanced_Sort")
@@ -273,6 +282,9 @@ class Ui_MenuBar(object):
         self.menuManually_Select_Bleaching.addAction(
             self.actionSelect_Bleach_Green_Channel
         )
+        self.menuManually_Select_Blinking.addAction(
+            self.actionSelect_Blink_Interval
+        )
         self.menuPredict_Trace_Type.addAction(
             self.actionPredict_Selected_Traces
         )
@@ -295,6 +307,9 @@ class Ui_MenuBar(object):
         self.menuAnalyze.addSeparator()
         self.menuAnalyze.addAction(
             self.menuManually_Select_Bleaching.menuAction()
+        )
+        self.menuAnalyze.addAction(
+            self.menuManually_Select_Blinking.menuAction()
         )
         self.menuAnalyze.addSeparator()
         self.menuAnalyze.addAction(self.actionFit_Hmm_Selected)
@@ -337,6 +352,9 @@ class Ui_MenuBar(object):
         self.menuAnalyze.setTitle(_translate("MenuBar", "Analyze"))
         self.menuManually_Select_Bleaching.setTitle(
             _translate("MenuBar", "Manually Select Bleaching")
+        )
+        self.menuManually_Select_Blinking.setTitle(
+            _translate("MenuBar", "Manually Select Blinking")
         )
         self.menuPredict_Trace_Type.setTitle(
             _translate("MenuBar", "Predict Trace Type")
@@ -496,6 +514,9 @@ class Ui_MenuBar(object):
         )
         self.actionSelect_Bleach_Green_Channel.setText(
             _translate("MenuBar", "Green Channel")
+        )
+        self.actionSelect_Blink_Interval.setText(
+            _translate("MenuBar", "Blink Interval")
         )
         self.actionAdvanced_Sort.setText(_translate("MenuBar", "Advanced Sort"))
         self.actionCheck_All.setText(_translate("MenuBar", "Check All"))

--- a/src/main/python/widgets/base_window.py
+++ b/src/main/python/widgets/base_window.py
@@ -174,6 +174,9 @@ class BaseWindow(QMainWindow):
         for f in (partial(self.triggerBleach, "green"), self.refreshPlot):
             self.ui.actionSelect_Bleach_Green_Channel.triggered.connect(f)
 
+        for f in (self.triggerBlink, self.refreshPlot):
+            self.ui.actionSelect_Blink_Interval.triggered.connect(f)
+
         # self.ui.actionFit_Hmm_Current.triggered.connect(
         #     partial(self.fitSingleTraceHiddenMarkovModel, True)
         # )


### PR DESCRIPTION
## Summary
- support manual blinking intervals in traces via new menu action
- allow TraceContainer to store and apply blink intervals
- update plot to visualize and zero selected blink segments
- expose new menu item "Manually Select Blinking"

## Testing
- `python3 -m py_compile src/main/python/lib/container.py src/main/python/widgets/trace_window.py src/main/python/widgets/base_window.py src/main/python/ui/_MenuBar.py`
- `pytest -q` *(fails: pyenv python version not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855600a086083249487d23cdaa9287a