### PR TITLE
Add clear blink interval feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ FRET (smFRET) fast and efficiently. The key feature is reverse-loading of ASCII 
 - Memory-free movie batch loading
 - Distribution plotting and fitting
 - Backwards-compatibility with iSMS-exported data
-- Manual blinking interval selection and export
+- Manual blinking interval selection, clearing and export
 
 If you'd like to play around with just the Keras/TensorFlow model, please go to https://github.com/komodovaran/DeepFRET-Model
 

--- a/src/main/python/ui/MenuBar.ui
+++ b/src/main/python/ui/MenuBar.ui
@@ -135,6 +135,7 @@
       <string>Manually Select Blinking</string>
      </property>
      <addaction name="actionSelect_Blink_Interval"/>
+     <addaction name="actionClear_Blink_Intervals"/>
     </widget>
     <widget class="QMenu" name="menuPredict_Trace_Type">
      <property name="title">
@@ -596,6 +597,14 @@
    </property>
    <property name="text">
     <string>Blink Interval</string>
+   </property>
+  </action>
+  <action name="actionClear_Blink_Intervals">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Clear Blink Intervals</string>
    </property>
   </action>
   <action name="actionAdvanced_Sort">

--- a/src/main/python/ui/_MenuBar.py
+++ b/src/main/python/ui/_MenuBar.py
@@ -224,6 +224,11 @@ class Ui_MenuBar(object):
         self.actionSelect_Blink_Interval.setObjectName(
             "actionSelect_Blink_Interval"
         )
+        self.actionClear_Blink_Intervals = QtWidgets.QAction(MenuBar)
+        self.actionClear_Blink_Intervals.setEnabled(False)
+        self.actionClear_Blink_Intervals.setObjectName(
+            "actionClear_Blink_Intervals"
+        )
         self.actionAdvanced_Sort = QtWidgets.QAction(MenuBar)
         self.actionAdvanced_Sort.setEnabled(False)
         self.actionAdvanced_Sort.setObjectName("actionAdvanced_Sort")
@@ -284,6 +289,9 @@ class Ui_MenuBar(object):
         )
         self.menuManually_Select_Blinking.addAction(
             self.actionSelect_Blink_Interval
+        )
+        self.menuManually_Select_Blinking.addAction(
+            self.actionClear_Blink_Intervals
         )
         self.menuPredict_Trace_Type.addAction(
             self.actionPredict_Selected_Traces
@@ -517,6 +525,9 @@ class Ui_MenuBar(object):
         )
         self.actionSelect_Blink_Interval.setText(
             _translate("MenuBar", "Blink Interval")
+        )
+        self.actionClear_Blink_Intervals.setText(
+            _translate("MenuBar", "Clear Blink Intervals")
         )
         self.actionAdvanced_Sort.setText(_translate("MenuBar", "Advanced Sort"))
         self.actionCheck_All.setText(_translate("MenuBar", "Check All"))

--- a/src/main/python/widgets/base_window.py
+++ b/src/main/python/widgets/base_window.py
@@ -178,6 +178,10 @@ class BaseWindow(QMainWindow):
         for f in (self.triggerBlink, self.refreshPlot):
             self.ui.actionSelect_Blink_Interval.triggered.connect(f)
 
+        self.ui.actionClear_Blink_Intervals.triggered.connect(
+            self.clearBlinkIntervals
+        )
+
         # self.ui.actionFit_Hmm_Current.triggered.connect(
         #     partial(self.fitSingleTraceHiddenMarkovModel, True)
         # )
@@ -919,6 +923,10 @@ class BaseWindow(QMainWindow):
         pass
 
     def triggerBlink(self):
+        """Override in subclass."""
+        pass
+
+    def clearBlinkIntervals(self):
         """Override in subclass."""
         pass
 

--- a/src/main/python/widgets/trace_window.py
+++ b/src/main/python/widgets/trace_window.py
@@ -118,6 +118,7 @@ class TraceWindow(BaseWindow):
             self.ui.actionSelect_Bleach_Red_Channel,
             self.ui.actionSelect_Bleach_Green_Channel,
             self.ui.actionSelect_Blink_Interval,
+            self.ui.actionClear_Blink_Intervals,
             self.ui.actionFit_Hmm_Selected,
             self.ui.actionPredict_Selected_Traces,
             self.ui.actionPredict_All_traces,
@@ -766,6 +767,29 @@ class TraceWindow(BaseWindow):
 
         self.clearMarkerLines()
         self.refreshPlot()
+
+    def clearBlinkIntervals(self):
+        """Clear manually selected blink intervals for the current trace."""
+        if self.currName is not None:
+            trace = self.currentTrace()
+            trace.blink_intervals = []
+            trace.hmm = None
+
+            self.refreshPlot()
+
+            histogram_window = self.windows[gvars.HistogramWindow]
+            transition_density_window = self.windows[gvars.TransitionDensityWindow]
+
+            histogram_window.getHistogramData()
+            histogram_window.gauss_params = None
+            if histogram_window.isVisible():
+                histogram_window.refreshPlot()
+
+            histogram_window.setPooledLifetimes()
+            transition_density_window.setClusteredTransitions()
+
+            if transition_density_window.isVisible():
+                transition_density_window.refreshPlot()
 
     def getCurrentLines(self, ax):
         """Get labels of currently plotted lines"""


### PR DESCRIPTION
## Summary
- add menu option to clear blink intervals
- wire up `clearBlinkIntervals` action
- implement clearing of blink intervals in TraceWindow
- document clearing blink intervals

## Testing
- `black . -l 80` *(fails: pyenv: black: command not found)*
- `pytest -q` *(fails: pyenv: pytest: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a61bdf1d483249754400309ef87f7